### PR TITLE
maven fails to resolve com.sun:tools dependencies on OSX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
       <artifactId>tools</artifactId>
       <version>6.0</version>
       <scope>system</scope>
-      <systemPath>${java.home}/../lib/tools.jar</systemPath>
+      <systemPath>${toolsjar}</systemPath>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -93,4 +93,32 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+
+  <profiles>
+    <profile>
+        <id>default-profile</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+            <file>
+                <exists>${java.home}/../lib/tools.jar</exists>
+            </file>
+        </activation>
+        <properties>
+            <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+        </properties>
+    </profile>
+    <profile>
+        <id>mac-profile</id>
+        <activation>
+            <activeByDefault>false</activeByDefault>
+            <file>
+                <exists>${java.home}/../Classes/classes.jar</exists>
+            </file>
+        </activation>
+        <properties>
+            <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
+        </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
OSX JDK don't follow the SUN JDK file structure for tools.jar location
