### PR TITLE
bridge to JavaMelody VirtualMachine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
       <version>2.0.19</version>
     </dependency>
     <dependency>
+      <groupId>net.bull.javamelody</groupId>
+      <artifactId>javamelody-core</artifactId>
+      <version>1.33.0</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>com.sun</groupId>
       <artifactId>tools</artifactId>
       <version>6.0</version>

--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -63,6 +63,19 @@ public class Main {
      * Loads the {@link VirtualMachine} class as the entry point to the attach API.
      */
     private Class loadAttachApi() throws MalformedURLException, ClassNotFoundException {
+
+        try {
+            Class vm = Class.forName("net.bull.javamelody.VirtualMachine");
+            // Reuse JavaMelody VirtualMachine to avoid conflict loading native code
+            Method m = vm.getDeclaredMethod("findVirtualMachineClass");
+            m.setAccessible(true);
+            Class c = (Class) m.invoke(vm);
+            System.out.println("re-using VirtualMachine from javamelody");
+            return c;
+        } catch (Exception e) {
+            // JavaMelody is not in classpath, or failed to reuse VirtualMachine class from this classloader
+        }
+
         File toolsJar = locateToolsJar();
 
         ClassLoader cl = wrapIntoClassLoader(toolsJar);


### PR DESCRIPTION
use javamelody VirtualMachine when present in classpath to avoid conflict loading native library from distinct classloaders
