### PR TITLE
Ignore generated Eclipse project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+/.project
+/.classpath
+/.settings/


### PR DESCRIPTION
Eclipse project files are generated by maven, thus it makes sense to ignore them from being checked in.
