### PR TITLE
New option "excludes" to provide a file with stacktraces that should be ignored

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/Listener.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Listener.java
@@ -192,7 +192,7 @@ public class Listener {
     /**
      * Allows to provide stacktrace-lines which cause the element to be excluded 
      */
-    public static List<String> EXCLUDES = new ArrayList<String>();
+    public static final List<String> EXCLUDES = new ArrayList<String>();
 
     /**
      * Tracing may cause additional files to be opened.


### PR DESCRIPTION
When using file-leak-detector in ci, there are often many cases where the file-open is ok, e.g. third-party-code which cannot be changed or code where certain files are open for a long time, e.g. database-connections or log-files.

This patch adds an option "excludes=FILE", which can be used to specify a list of stack-trace-lines which denote file-opens which can be ignored and thus do not appear in the dumps.

If these excludes are done properly, I can then add a check in CI after the tests which ensures that the dump does not contain any entry at all, causing testing to fail as soon as new unclosed file-opens are added.
