### PR TITLE
add possibility to define ExternalListener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+.settings
+.classpath
+.project

--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -67,6 +67,9 @@ public class AgentMain {
                 } else
                 if(t.startsWith("error=")) {
                     Listener.ERROR = new PrintWriter(new FileOutputStream(t.substring(6)));
+                } else
+                if(t.startsWith("listener=")) {
+                    Listener.EXTERNAL = (ExternalListener) AgentMain.class.getClassLoader().loadClass(t.substring(9)).newInstance();
                 } else {
                     System.err.println("Unknown option: "+t);
                     usageAndQuit();

--- a/src/main/java/org/kohsuke/file_leak_detector/ExternalListener.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/ExternalListener.java
@@ -1,0 +1,28 @@
+package org.kohsuke.file_leak_detector;
+
+import java.io.File;
+
+/**
+ * 
+ * Allows external listeners for the open file and open socket events.
+ * 
+ * @author Michal Linhard (michal@linhard.sk)
+ */
+public interface ExternalListener {
+   /**
+    * 
+    * Called when a new file is opened.
+    * 
+    * @param obj
+    * @param file
+    */
+   void open(Object obj, File file);
+
+   /**
+    * 
+    * Called when a new socket is opened.
+    * 
+    * @param obj
+    */
+   void openSocket(Object obj);
+}

--- a/src/main/java/org/kohsuke/file_leak_detector/Listener.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Listener.java
@@ -69,7 +69,7 @@ public class Listener {
         }
 
         public void dump(String prefix, PrintWriter pw) {
-            pw.println(prefix + file + " by thread:" + threadName + " on " + new Date(time));
+            pw.println(prefix + file + " by thread:" + threadName + " on " + format(time));
             super.dump(prefix,pw);
         }
     }
@@ -96,7 +96,7 @@ public class Listener {
             String peer = this.peer;
             if (peer==null)  peer=getRemoteAddress(socket);
 
-            ps.println(prefix+"socket to "+peer+" by thread:"+threadName+" on "+new Date(time));
+            ps.println(prefix+"socket to "+peer+" by thread:"+threadName+" on "+format(time));
             super.dump(prefix,ps);
         }
     }
@@ -123,7 +123,7 @@ public class Listener {
             String address = this.address;
             if (address==null)  address=getLocalAddress(socket);
 
-            ps.println(prefix+"server socket at "+address+" by thread:"+threadName+" on "+new Date(time));
+            ps.println(prefix+"server socket at "+address+" by thread:"+threadName+" on "+format(time));
             super.dump(prefix,ps);
         }
     }
@@ -139,7 +139,7 @@ public class Listener {
         }
 
         public void dump(String prefix, PrintWriter ps) {
-            ps.println(prefix+"socket channel by thread:"+threadName+" on "+new Date(time));
+            ps.println(prefix+"socket channel by thread:"+threadName+" on "+format(time));
             super.dump(prefix,ps);
         }
     }
@@ -176,6 +176,11 @@ public class Listener {
     /*package*/ static boolean AGENT_INSTALLED = false;
 
     /**
+     * Implementation of {@link ExternalListener}.
+     */
+    public static ExternalListener EXTERNAL = null;
+
+    /**
      * Returns true if the leak detector agent is running.
      */
     public static boolean isAgentInstalled() {
@@ -195,6 +200,8 @@ public class Listener {
      *      File being opened.
      */
     public static synchronized void open(Object _this, File f) {
+       if (EXTERNAL != null)
+           EXTERNAL.open(_this, f);
         put(_this, new FileRecord(f));
     }
 
@@ -202,6 +209,8 @@ public class Listener {
      * Called when a socket is opened.
      */
     public static synchronized void openSocket(Object _this) {
+        if (EXTERNAL != null)
+            EXTERNAL.openSocket(_this);
         // intercept when
         if (_this instanceof SocketImpl) {
             try {
@@ -286,6 +295,14 @@ public class Listener {
         }
     }
     
+    private static String format(long time) {
+        try {
+            return new Date(time).toString();
+        } catch (Exception e) {
+            return Long.toString(time);
+        }
+    }
+
     private static Field SOCKETIMPL_SOCKET,SOCKETIMPL_SERVER_SOCKET;
     
     static {


### PR DESCRIPTION
this might be handy when I have a simple test app where I want to listen to the open file and open socket events
you just add the agent option listener=com.example.ExternalListenerImpl where ExternalListenerImpl class implements org.kohsuke.file_leak_detector.ExternalListener
