### PR TITLE
Add option "dumpatshutdown" to print out all remaining file handles during shutdown

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -75,12 +75,12 @@ public class AgentMain {
                     ActivityListener.LIST.add((ActivityListener) AgentMain.class.getClassLoader().loadClass(t.substring(9)).newInstance());
                 } else
                 if(t.equals("dumpatshutdown")) {
-                	Runtime.getRuntime().addShutdownHook(new Thread("File handles dumping shutdown hook") {
-						@Override
-						public void run() {
-							Listener.dump(System.err);
-						}
-                	});
+                    Runtime.getRuntime().addShutdownHook(new Thread("File handles dumping shutdown hook") {
+                        @Override
+                        public void run() {
+                            Listener.dump(System.err);
+                        }
+                    });
                 } else {
                     System.err.println("Unknown option: "+t);
                     usageAndQuit();


### PR DESCRIPTION
Adds an option which dumps file handles which were not closed during the program execution. This is useful for CI runs where it is desirable to have the list of unclosed handles as part of the build-output. Then you can fail the build via output-parsing to fail the build on newly added handles.

Note: This will likely conflict with changes in pull request #10, I will update the pull-requests as soon as one of them is merged.
