### PR TITLE
New option "excludes" to provide a file with stacktraces that should be ignored

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -13,6 +13,7 @@ import org.kohsuke.file_leak_detector.transform.TransformerImpl;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -81,6 +82,25 @@ public class AgentMain {
                             Listener.dump(System.err);
                         }
                     });
+                } else
+                if(t.startsWith("excludes=")) {
+                    BufferedReader reader = new BufferedReader(new FileReader(t.substring(9)));
+                    try {
+	                    while (true) {
+	                    	String line = reader.readLine();
+	                    	if(line == null) {
+	                    		break;
+	                    	}
+
+	                    	String str = line.trim();
+	                        // add the entries from the excludes-file, but filter out empty ones and comments
+	                    	if(!str.isEmpty() && !str.startsWith("#")) {
+	                    		Listener.EXCLUDES.add(str);
+	                    	}
+	                    }
+                    } finally {
+                    	reader.close();
+                    }
                 } else {
                     System.err.println("Unknown option: "+t);
                     usageAndQuit();
@@ -164,6 +184,8 @@ public class AgentMain {
         System.err.println("  strong        - Don't let GC auto-close leaking file descriptors");
         System.err.println("  listener=S    - Specify the fully qualified name of ActivityListener class to activate from beginning");
         System.err.println("  dumpatshutdown- Don't let GC auto-close leaking file descriptors");
+        System.err.println("  excludes=File - Exclude any opened file where a line in the given exclude-file matches");
+        System.err.println("                  one of the lines from the stacktrace of the open-call.");
     }
 
     static List<ClassTransformSpec> createSpec() {

--- a/src/main/java/org/kohsuke/file_leak_detector/Listener.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Listener.java
@@ -56,6 +56,36 @@ public class Listener {
                 pw.println("\tat " + trace[i]);
             pw.flush();
         }
+        
+        public boolean exclude() {
+        	if(EXCLUDES.isEmpty()) {
+        		return false;
+        	}
+
+            StackTraceElement[] trace = stackTrace.getStackTrace();
+            int i=0;
+            // skip until we find the Method.invoke() that called us
+            for (; i<trace.length; i++) {
+				if(trace[i].getClassName().equals("java.lang.reflect.Method")) {
+                    i++;
+                    break;
+                }
+			}
+            
+            // check the rest
+            for (; i < trace.length; i++) {
+            	String t = trace[i].toString();
+            	for(String exclude : EXCLUDES) {
+            		// skip empty lines
+					if(t.contains(exclude)) {
+						return true;
+					}
+            	}
+			}
+
+            // no matchine exclude found
+            return false;
+        }
     }
 
     /**
@@ -160,6 +190,11 @@ public class Listener {
     public static PrintWriter ERROR = new PrintWriter(System.err);
 
     /**
+     * Allows to provide stacktrace-lines which cause the element to be excluded 
+     */
+    public static final List<String> EXCLUDES = new ArrayList<String>();
+
+    /**
      * Tracing may cause additional files to be opened.
      * In such a case, avoid infinite recursion.
      */
@@ -243,6 +278,16 @@ public class Listener {
     }
     
     private static synchronized void put(Object _this, Record r) {
+    	// handle excludes
+    	if(r.exclude()) {
+            if(TRACE!=null && !tracing) {
+                tracing = true;
+                r.dump("Excluded ",TRACE);
+                tracing = false;
+            }
+			return;
+		}
+
         TABLE.put(_this, r);
         if(TABLE.size()>THRESHOLD) {
             THRESHOLD=999999;


### PR DESCRIPTION
_This rebases changes from pull #10 onto the latest master as there are a number of conflicts otherwise._

When using file-leak-detector in ci, there are often many cases where the file-open is ok, e.g. third-party-code which cannot be changed or code where certain files are open for a long time, e.g. database-connections or log-files.

This patch adds an option "excludes=FILE", which can be used to specify a list of stack-trace-lines which denote file-opens which can be ignored and thus do not appear in the dumps.

If these excludes are done properly, I can then add a check in CI after the tests which ensures that the dump does not contain any entry at all, causing testing to fail as soon as new unclosed file-opens are added.
