### PR TITLE
Replace use of property java.home by environment variable JAVA_HOME where the former points to a JRE and the later to a JDK. The JRE is not aware of the tools.jar.

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -107,7 +107,7 @@ public class Main {
      * Locates the {@code tools.jar} file. Note that on Mac there's no such file but the class is still loadable.
      */
     private File locateToolsJar() {
-        File home = new File(System.getProperty("java.home"));
+        File home = new File(System.getenv("JAVA_HOME"));
         return new File(home,"../lib/tools.jar");
     }
 


### PR DESCRIPTION
java.home does not represent JAVA_HOME. For reference, see the list of Java properties: http://docs.oracle.com/javase/tutorial/essential/environment/sysprop.html

I found and fixed the bug after not being able to use the application from command line with Java 7.
