### PR TITLE
Remove tools.jar dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,13 +131,6 @@
       <version>2.0.16</version>
     </dependency>
     <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>6.0</version>
-      <scope>system</scope>
-      <systemPath>${toolsjar}</systemPath>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.0.1</version>
@@ -150,33 +143,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-        <id>default-profile</id>
-        <activation>
-            <activeByDefault>true</activeByDefault>
-            <file>
-                <exists>${java.home}/../lib/tools.jar</exists>
-            </file>
-        </activation>
-        <properties>
-            <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-        </properties>
-    </profile>
-    <profile>
-        <id>mac-profile</id>
-        <activation>
-            <activeByDefault>false</activeByDefault>
-            <file>
-                <exists>${java.home}/../Classes/classes.jar</exists>
-            </file>
-        </activation>
-        <properties>
-            <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
-        </properties>
-    </profile>
-  </profiles>
 
   <licenses>
     <license>


### PR DESCRIPTION
This appears to have been removed once before, in https://github.com/kohsuke/file-leak-detector/pull/32.  I don't see an obvious commit where it was reintroduced, so it's unclear to me why the dependency is still in the ```master``` branch.

JEP 220 (https://openjdk.java.net/jeps/220) removed tools.jar from the JDK, so a dependency on tools.jar causes a build failure with JDK 9 and later.  It will also cause build failures for any project that builds
with JDK 9+ and that has a dependency upon file-leak-detector.

Without this pull request, ```mvn clean package``` with ```JAVA_HOME``` pointed to OpenJDK 11.0.2 failed:

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$2 (file:/usr/share/maven/lib/sisu-guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$2
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kohsuke:file-leak-detector:jar:1.14-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ line 38, column 15
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-shade-plugin is missing. @ line 81, column 15
[WARNING] 'dependencies.dependency.systemPath' for com.sun:tools:jar refers to a non-existing file /home/melissa/Downloads/jdk-11.0.2/../lib/tools.jar. Please verify that you run Maven using a JDK and not just a JRE. @ line 138, column 19
[WARNING] 'reporting.plugins.plugin.version' for org.apache.maven.plugins:maven-javadoc-plugin is missing. @ org.kohsuke:pom:19, /home/melissa/.m2/repository/org/kohsuke/pom/19/pom-19.pom, line 138, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] Inspecting build with total of 1 modules...
[INFO] Installing Nexus Staging features:
[INFO]   ... total of 1 executions of maven-deploy-plugin replaced with nexus-staging-maven-plugin
[INFO]                                                                         
[INFO] ------------------------------------------------------------------------
[INFO] Building File Leak Detector 1.14-SNAPSHOT
[INFO] ------------------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.134s
[INFO] Finished at: Fri Mar 22 11:20:17 CDT 2019
[INFO] Final Memory: 9M/34M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project file-leak-detector: Could not resolve dependencies for project org.kohsuke:file-leak-detector:jar:1.14-SNAPSHOT: Could not find artifact com.sun:tools:jar:6.0 at specified path /home/melissa/Downloads/jdk-11.0.2/../lib/tools.jar -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

With this pull request, ```mvn clean package -DskipTests``` should pass.  ```mvn clean package``` will still fail due to test failures, which I haven't attempted to fix here.