### PR TITLE
Java11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
   </build>
 
   <properties>
-    <asm.version>6.0_BETA</asm.version>
+    <asm.version>7.2</asm.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
                   <shadedPattern>org.kohsuke.file_leak_detector.args4j</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.kohsuke.asm6</pattern>
+                  <pattern>org.objectweb.asm</pattern>
                   <shadedPattern>org.kohsuke.file_leak_detector.asm6</shadedPattern>
                 </relocation>
               </relocations>
@@ -119,11 +119,32 @@
     </plugins>
   </build>
 
+  <properties>
+    <asm.version>6.0_BETA</asm.version>
+  </properties>
+
   <dependencies>
     <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>asm6</artifactId>
-      <version>6.0_BETA</version>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-commons</artifactId>
+      <version>${asm.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-util</artifactId>
+      <version>${asm.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm-analysis</artifactId>
+      <version>${asm.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>args4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -131,13 +131,6 @@
       <version>2.0.16</version>
     </dependency>
     <dependency>
-      <groupId>com.sun</groupId>
-      <artifactId>tools</artifactId>
-      <version>6.0</version>
-      <scope>system</scope>
-      <systemPath>${toolsjar}</systemPath>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.0.1</version>
@@ -150,33 +143,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <profiles>
-    <profile>
-        <id>default-profile</id>
-        <activation>
-            <activeByDefault>true</activeByDefault>
-            <file>
-                <exists>${java.home}/../lib/tools.jar</exists>
-            </file>
-        </activation>
-        <properties>
-            <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-        </properties>
-    </profile>
-    <profile>
-        <id>mac-profile</id>
-        <activation>
-            <activeByDefault>false</activeByDefault>
-            <file>
-                <exists>${java.home}/../Classes/classes.jar</exists>
-            </file>
-        </activation>
-        <properties>
-            <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
-        </properties>
-    </profile>
-  </profiles>
 
   <licenses>
     <license>

--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -1,8 +1,8 @@
 package org.kohsuke.file_leak_detector;
 
-import static org.kohsuke.asm6.Opcodes.ALOAD;
-import static org.kohsuke.asm6.Opcodes.ASM5;
-import static org.kohsuke.asm6.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASM5;
+import static org.objectweb.asm.Opcodes.ASTORE;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -34,10 +34,10 @@ import java.util.concurrent.ThreadFactory;
 import java.util.zip.ZipFile;
 
 import org.kohsuke.args4j.CmdLineException;
-import org.kohsuke.asm6.Label;
-import org.kohsuke.asm6.MethodVisitor;
-import org.kohsuke.asm6.Type;
-import org.kohsuke.asm6.commons.LocalVariablesSorter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.LocalVariablesSorter;
 import org.kohsuke.file_leak_detector.transform.ClassTransformSpec;
 import org.kohsuke.file_leak_detector.transform.CodeGenerator;
 import org.kohsuke.file_leak_detector.transform.MethodAppender;

--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -198,20 +198,21 @@ public class AgentMain {
     }
 
     static void printOptions() {
-        System.err.println("  help          - show the help screen.");
-        System.err.println("  trace         - log every open/close operation to stderr.");
-        System.err.println("  trace=FILE    - log every open/close operation to the given file.");
-        System.err.println("  error=FILE    - if 'too many open files' error is detected, send the dump here.");
-        System.err.println("                  by default it goes to stderr.");
-        System.err.println("  threshold=N   - instead of waiting until 'too many open files', dump once");
-        System.err.println("                  we have N descriptors open.");
-        System.err.println("  http=PORT     - Run a mini HTTP server that you can access to get stats on demand");
-        System.err.println("                  Specify 0 to choose random available port, -1 to disable, which is default.");
-        System.err.println("  strong        - Don't let GC auto-close leaking file descriptors");
-        System.err.println("  listener=S    - Specify the fully qualified name of ActivityListener class to activate from beginning");
-        System.err.println("  dumpatshutdown- Dump open file handles at shutdown");
-        System.err.println("  excludes=FILE - Ignore files opened directly/indirectly in specific methods.");
-        System.err.println("                  File lists 'some.pkg.ClassName.methodName' patterns.");
+        System.err.println("  help           - Show the help screen.");
+        System.err.println("  noexit         - Don't exit after showing the help screen.");
+        System.err.println("  trace          - Log every open/close operation to stderr.");
+        System.err.println("  trace=FILE     - Log every open/close operation to the given file.");
+        System.err.println("  error=FILE     - If 'too many open files' error is detected, send the dump here.");
+        System.err.println("                   By default it goes to stderr.");
+        System.err.println("  threshold=N    - Instead of waiting until 'too many open files', dump once");
+        System.err.println("                   we have N descriptors open.");
+        System.err.println("  http=PORT      - Run a mini HTTP server that you can access to get stats on demand.");
+        System.err.println("                   Specify 0 to choose random available port, -1 to disable, which is default.");
+        System.err.println("  strong         - Don't let GC auto-close leaking file descriptors.");
+        System.err.println("  listener=S     - Specify the fully qualified name of ActivityListener class to activate from beginning.");
+        System.err.println("  dumpatshutdown - Dump open file handles at shutdown.");
+        System.err.println("  excludes=FILE  - Ignore files opened directly/indirectly in specific methods.");
+        System.err.println("                   File lists 'some.pkg.ClassName.methodName' patterns.");
     }
 
     static List<ClassTransformSpec> createSpec() {

--- a/src/main/java/org/kohsuke/file_leak_detector/Main.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Main.java
@@ -101,6 +101,9 @@ public class Main {
         URL jar = toolsJar.toURI().toURL();
 
         ClassLoader base = getClass().getClassLoader();
+        if (!toolsJar.exists()) {
+            return base;
+        }
         if (base instanceof URLClassLoader) {
             try {
                 Method addURL = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
@@ -1,24 +1,24 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import static org.kohsuke.asm6.Opcodes.AASTORE;
-import static org.kohsuke.asm6.Opcodes.ACONST_NULL;
-import static org.kohsuke.asm6.Opcodes.ALOAD;
-import static org.kohsuke.asm6.Opcodes.ANEWARRAY;
-import static org.kohsuke.asm6.Opcodes.ASM6;
-import static org.kohsuke.asm6.Opcodes.ASTORE;
-import static org.kohsuke.asm6.Opcodes.ATHROW;
-import static org.kohsuke.asm6.Opcodes.DUP;
-import static org.kohsuke.asm6.Opcodes.GETSTATIC;
-import static org.kohsuke.asm6.Opcodes.GOTO;
-import static org.kohsuke.asm6.Opcodes.ICONST_0;
-import static org.kohsuke.asm6.Opcodes.IFEQ;
-import static org.kohsuke.asm6.Opcodes.INVOKESTATIC;
-import static org.kohsuke.asm6.Opcodes.INVOKEVIRTUAL;
-import static org.kohsuke.asm6.Opcodes.POP;
+import static org.objectweb.asm.Opcodes.AASTORE;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ANEWARRAY;
+import static org.objectweb.asm.Opcodes.ASM6;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.ATHROW;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.ICONST_0;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.POP;
 
-import org.kohsuke.asm6.Label;
-import org.kohsuke.asm6.MethodVisitor;
-import org.kohsuke.asm6.Type;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 /**
  * Convenience method to generate bytecode.

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
@@ -4,7 +4,7 @@ import static org.objectweb.asm.Opcodes.AASTORE;
 import static org.objectweb.asm.Opcodes.ACONST_NULL;
 import static org.objectweb.asm.Opcodes.ALOAD;
 import static org.objectweb.asm.Opcodes.ANEWARRAY;
-import static org.objectweb.asm.Opcodes.ASM6;
+import static org.objectweb.asm.Opcodes.ASM7;
 import static org.objectweb.asm.Opcodes.ASTORE;
 import static org.objectweb.asm.Opcodes.ATHROW;
 import static org.objectweb.asm.Opcodes.DUP;
@@ -27,7 +27,7 @@ import org.objectweb.asm.Type;
  */
 public class CodeGenerator extends MethodVisitor {
     public CodeGenerator(MethodVisitor mv) {
-        super(ASM6,mv);
+        super(ASM7,mv);
     }
 
     public void println(String msg) {

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/MethodAppender.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/MethodAppender.java
@@ -1,8 +1,8 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import org.kohsuke.asm6.MethodVisitor;
+import org.objectweb.asm.MethodVisitor;
 
-import static org.kohsuke.asm6.Opcodes.*;
+import static org.objectweb.asm.Opcodes.*;
 
 /**
  * {@link MethodTransformSpec} that adds some code right before the return statement.

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/MethodAppender.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/MethodAppender.java
@@ -22,7 +22,7 @@ public abstract class MethodAppender extends MethodTransformSpec {
     @Override
     public MethodVisitor newAdapter(MethodVisitor base, int access, String name, String desc, String signature, String[] exceptions) {
         final CodeGenerator cg = new CodeGenerator(base);
-        return new MethodVisitor(ASM6,base) {
+        return new MethodVisitor(ASM7,base) {
             @Override
             public void visitInsn(int opcode) {
                 switch (opcode) {

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/MethodTransformSpec.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/MethodTransformSpec.java
@@ -1,6 +1,6 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import org.kohsuke.asm6.MethodVisitor;
+import org.objectweb.asm.MethodVisitor;
 
 /**
  * Transforms a specific method.

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/TransformerImpl.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/TransformerImpl.java
@@ -37,8 +37,8 @@ public class TransformerImpl implements ClassFileTransformer {
             return classfileBuffer;
 
         ClassReader cr = new ClassReader(classfileBuffer);
-        ClassWriter cw = new ClassWriter(/*ClassWriter.COMPUTE_FRAMES|*/ClassWriter.COMPUTE_MAXS);
-        cr.accept(new ClassVisitor(ASM6,cw) {
+        ClassWriter cw = new ClassWriter(ClassWriter.COMPUTE_FRAMES|ClassWriter.COMPUTE_MAXS);
+        cr.accept(new ClassVisitor(ASM7,cw) {
             @Override
             public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
                 MethodVisitor base = super.visitMethod(access, name, desc, signature, exceptions);

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/TransformerImpl.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/TransformerImpl.java
@@ -1,9 +1,9 @@
 package org.kohsuke.file_leak_detector.transform;
 
-import org.kohsuke.asm6.ClassReader;
-import org.kohsuke.asm6.ClassVisitor;
-import org.kohsuke.asm6.ClassWriter;
-import org.kohsuke.asm6.MethodVisitor;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
 
 import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
@@ -12,8 +12,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.kohsuke.asm6.ClassReader.*;
-import static org.kohsuke.asm6.Opcodes.*;
+import static org.objectweb.asm.ClassReader.*;
+import static org.objectweb.asm.Opcodes.*;
 
 /**
  * @author Kohsuke Kawaguchi

--- a/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
@@ -10,10 +10,13 @@ import org.kohsuke.asm6.util.CheckClassAdapter;
 import org.kohsuke.file_leak_detector.transform.ClassTransformSpec;
 import org.kohsuke.file_leak_detector.transform.TransformerImpl;
 
+import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.zip.ZipFile;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -42,7 +45,13 @@ public class TransformerTest {
 //        o.write(data2);
 //        o.close();
 
-        CheckClassAdapter.verify(new ClassReader(data2), false, new PrintWriter(System.err));
+        String errors;
+        ClassReader classReader = new ClassReader(data2);
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            CheckClassAdapter.verify(classReader, false, new PrintWriter(baos));
+            errors = new String(baos.toByteArray(), UTF_8);
+        }
+        assertTrue("Verification failed for " + c + "\n" + errors, errors.isEmpty());
     }
     
     @Parameters

--- a/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/TransformerTest.java
@@ -5,8 +5,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.kohsuke.asm6.ClassReader;
-import org.kohsuke.asm6.util.CheckClassAdapter;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.util.CheckClassAdapter;
 import org.kohsuke.file_leak_detector.transform.ClassTransformSpec;
 import org.kohsuke.file_leak_detector.transform.TransformerImpl;
 


### PR DESCRIPTION
@kohsuke 

This PR tries to address issue #46 and adds support for Java11.
This PR essentially upgrades asm from version 6.0 to version 7.2 .

I have checked the changes against both Java8 and Java11 and was able to successfully:
- compile the project (_mvn clean package_),
- start an application with the agent jar attached,
- attach the agent to a running application,
- list open files in the built-in HTTP server in both of the above scenarios.

I have gathered less invasive changes in the 1<sup>st</sup> commit ( e9ac84a ) and moved it into PR #47 hoping they could be merged faster.

Due to lack of `org.kohsuke.asm7` package I had to switch to the upstream version ( `org.ow2.asm` ) . I'm not sure why asm6 has been re-packaged in the first place TBH, but the detector appears to work just fine without that re-packaging.

Of course, once there is `org.kohsuke.asm7` available switching to `org.ow2.asm` won't be necessary.