### PR TITLE
Add `-Xverify:none` to docs for OpenJ9

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,9 +97,9 @@ This project uses the JVM's support for instrumenting Java classes during startu
 It adds code to various places where files or sockets are opened and closed
 to print out which file descriptors have not been closed correctly.
 
-== OpenJ9 Caveats
+== `stack shape inconsistent` error
 
-Since this project modifies core java bytecode it requires the `-Xverify:none` argument when running the agent when using OpenJ9.  See https://github.com/jenkinsci/lib-file-leak-detector/issues/37[#37] and https://github.com/jenkinsci/lib-file-leak-detector/pull/50#issue-602359846[#50] for details.
+Since this project modifies core java bytecode it requires the `-Xverify:none` argument when running the agent for some versions of the JVM (OpenJ9 version 1.8.x for example).  See https://github.com/jenkinsci/lib-file-leak-detector/issues/37[#37] and https://github.com/jenkinsci/lib-file-leak-detector/pull/50#issue-602359846[#50] for details.
 
 == Documentation
 

--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ Without any options, this tool silently records file open/close operations and u
 
 [source,sh]
 ----
-$ java -javaagent:path/to/file-leak-detector.jar ...your usual Java arguments follow...
+$ java -javaagent:path/to/file-leak-detector.jar -Xverify:none ...your usual Java arguments follow...
 ----
 
 There are several options you can pass to the agent.
@@ -31,14 +31,14 @@ For example, to dump the open file descriptors when the total number reaches 200
 
 [source,sh]
 ----
-$ java -javaagent:path/to/file-leak-detector.jar=threshold=200 ...your usual Java arguments follow...
+$ java -javaagent:path/to/file-leak-detector.jar=threshold=200 -Xverify:none ...your usual Java arguments follow...
 ----
 
 Or to have it run a mini HTTP server so that you can access the information from your browser, do the following and open http://localhost:19999/:
 
 [source,sh]
 ----
-$ java -javaagent:path/to/file-leak-detector.jar=http=19999 ...your usual Java arguments follow...
+$ java -javaagent:path/to/file-leak-detector.jar=http=19999 -Xverify:none ...your usual Java arguments follow...
 ----
 
 Use the help option to see the help screen for the complete list of options:
@@ -57,7 +57,7 @@ Options can be specified in the second argument in the same format you do to the
 
 [source,sh]
 ----
-$ java -jar path/to/file-leak-detector.jar 1500 threshold=200,strong
+$ java -jar path/to/file-leak-detector.jar 1500 threshold=200,strong -Xverify:none
 ----
 
 == Supported options

--- a/README.adoc
+++ b/README.adoc
@@ -23,7 +23,7 @@ Without any options, this tool silently records file open/close operations and u
 
 [source,sh]
 ----
-$ java -javaagent:path/to/file-leak-detector.jar -Xverify:none ...your usual Java arguments follow...
+$ java -javaagent:path/to/file-leak-detector.jar ...your usual Java arguments follow...
 ----
 
 There are several options you can pass to the agent.
@@ -31,14 +31,14 @@ For example, to dump the open file descriptors when the total number reaches 200
 
 [source,sh]
 ----
-$ java -javaagent:path/to/file-leak-detector.jar=threshold=200 -Xverify:none ...your usual Java arguments follow...
+$ java -javaagent:path/to/file-leak-detector.jar=threshold=200 ...your usual Java arguments follow...
 ----
 
 Or to have it run a mini HTTP server so that you can access the information from your browser, do the following and open http://localhost:19999/:
 
 [source,sh]
 ----
-$ java -javaagent:path/to/file-leak-detector.jar=http=19999 -Xverify:none ...your usual Java arguments follow...
+$ java -javaagent:path/to/file-leak-detector.jar=http=19999 ...your usual Java arguments follow...
 ----
 
 Use the help option to see the help screen for the complete list of options:
@@ -57,7 +57,7 @@ Options can be specified in the second argument in the same format you do to the
 
 [source,sh]
 ----
-$ java -jar path/to/file-leak-detector.jar 1500 threshold=200,strong -Xverify:none
+$ java -jar path/to/file-leak-detector.jar 1500 threshold=200,strong
 ----
 
 == Supported options
@@ -96,6 +96,10 @@ This project uses the JVM's support for instrumenting Java classes during startu
 
 It adds code to various places where files or sockets are opened and closed
 to print out which file descriptors have not been closed correctly.
+
+== OpenJ9 Caveats
+
+Since this project modifies core java bytecode it requires the `-Xverify:none` argument when running the agent when using OpenJ9.  See https://github.com/jenkinsci/lib-file-leak-detector/issues/37[#37] and https://github.com/jenkinsci/lib-file-leak-detector/pull/50#issue-602359846[#50] for details.
 
 == Documentation
 

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
                 <exclude>**/TransformerTest.java</exclude>
                 <exclude>**/AgentMainTest.java</exclude>
               </excludes>
-              <argLine>-javaagent:"${project.build.directory}/file-leak-detector-${project.version}-jar-with-dependencies.jar"</argLine>
+              <argLine>-javaagent:"${project.build.directory}/file-leak-detector-${project.version}-jar-with-dependencies.jar" -Xverify:none</argLine>
             </configuration>
           </execution>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
                 <exclude>**/TransformerTest.java</exclude>
                 <exclude>**/AgentMainTest.java</exclude>
               </excludes>
-              <argLine>-javaagent:"${project.build.directory}/file-leak-detector-${project.version}-jar-with-dependencies.jar" -Xverify:none</argLine>
+              <argLine>-javaagent:"${project.build.directory}/file-leak-detector-${project.version}-jar-with-dependencies.jar"</argLine>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This PR tries to address issue #37.

On newer versions of java bytecode is verified before it is run.  Since
this agent modifies core java bytecode it needs to bypass this
verification.  To turn the verification off pass -Xverify:none as an
argument when running the agent.  Fixed in unit tests and docs.

Details: https://www.ibm.com/support/pages/ibm-java-linux-howto-resolving-javalangverifyerror-jvmvrfy012-stack-shape-inconsistent