### PR TITLE
Exclude unneeded args4j resources from shaded JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
                   <artifact>args4j:args4j</artifact>
                   <excludes>
                     <exclude>LICENSE</exclude>
+                    <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>OSGI-OPT/**/*.html</exclude>
                     <exclude>OSGI-OPT/**/*.java</exclude>
                   </excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,16 @@
                   <shadedPattern>org.kohsuke.file_leak_detector.asm6</shadedPattern>
                 </relocation>
               </relocations>
+              <filters>
+                <filter>
+                  <artifact>args4j:args4j</artifact>
+                  <excludes>
+                    <exclude>LICENSE</exclude>
+                    <exclude>OSGI-OPT/**/*.html</exclude>
+                    <exclude>OSGI-OPT/**/*.java</exclude>
+                  </excludes>
+                </filter>
+              </filters>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Amends #69. Newer versions of `args4j` have a bunch of cruft in the JAR file, which we then pull in when sharing. To keep our shaded JAR roughly the same as it was before, excluded this unneeded cruft.