### PR TITLE
Fine-grained SpotBugs exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
     <asm.version>9.2</asm.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spotbugs.skip>true</spotbugs.skip> <!-- TODO lots of violations -->
+    <spotbugs.excludeFilterFile>${project.basedir}/src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
   </properties>
 
   <scm>

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+  <!--
+    Exclusions in this section have been triaged and determined to be false positives.
+  -->
+  <Match>
+    <Or>
+      <!-- Pending https://github.com/spotbugs/spotbugs/issues/1515 -->
+      <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
+    </Or>
+  </Match>
+  <!--
+    Here lies technical debt. Exclusions in this section have not yet been triaged. When working on
+    on this section, pick an exclusion to triage, then:
+    - If it is a false positive, add a @SuppressFBWarnings(value = "[…]", justification = "[…]")
+      annotation indicating the reason why it is a false positive, then remove the exclusion from
+      this section.
+    - If it is not a false positive, fix the bug, then remove the exclusion from this section.
+   -->
+  <Match>
+    <Confidence value="1"/>
+    <Or>
+      <And>
+        <Bug pattern="DM_DEFAULT_ENCODING"/>
+        <Or>
+          <Class name="org.kohsuke.file_leak_detector.AgentMain"/>
+          <Class name="org.kohsuke.file_leak_detector.AgentMain$3$1"/>
+          <Class name="org.kohsuke.file_leak_detector.Listener"/>
+        </Or>
+      </And>
+    </Or>
+  </Match>
+  <Match>
+    <Confidence value="2"/>
+    <Or>
+      <And>
+        <Bug pattern="MS_MUTABLE_COLLECTION_PKGPROTECT"/>
+        <Class name="org.kohsuke.file_leak_detector.Listener"/>
+      </And>
+      <And>
+        <Bug pattern="MS_PKGPROTECT"/>
+        <Class name="org.kohsuke.file_leak_detector.Listener"/>
+      </And>
+      <And>
+        <Bug pattern="PATH_TRAVERSAL_IN"/>
+        <Or>
+          <Class name="org.kohsuke.file_leak_detector.AgentMain"/>
+          <Class name="org.kohsuke.file_leak_detector.Main"/>
+        </Or>
+      </And>
+      <And>
+        <Bug pattern="PATH_TRAVERSAL_OUT"/>
+        <Class name="org.kohsuke.file_leak_detector.AgentMain"/>
+      </And>
+      <And>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+        <Or>
+          <Class name="org.kohsuke.file_leak_detector.AgentMain"/>
+          <Class name="org.kohsuke.file_leak_detector.AgentMain$3"/>
+        </Or>
+      </And>
+      <And>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT"/>
+        <Class name="org.kohsuke.file_leak_detector.AgentMain"/>
+      </And>
+      <And>
+        <Bug pattern="UNENCRYPTED_SERVER_SOCKET"/>
+        <Class name="org.kohsuke.file_leak_detector.AgentMain"/>
+      </And>
+    </Or>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
### Problem

Currently, we exclude any medium-threshold SpotBugs violations. This means that existing violations don't trip up the build, but it also means we won't notice if new medium-threshold violations get introduced.

### Solution

Add an exclude filter file with fine-grained suppressions of specific medium-threshold violations for the classes that currently violate them. This way, the build remains green, but if a new medium-threshold violation gets introduced, we would notice that right away.