### PR TITLE
Disable Socket to support (broken on Java 17+)

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -431,6 +431,7 @@ public class AgentMain {
     /**
      * Used to intercept {@link java.net.PlainSocketImpl#accept(SocketImpl)}
      */
+    @SuppressWarnings("JavadocReference")
     private static class AcceptInterceptor extends MethodAppender {
         public AcceptInterceptor(String name, String desc) {
             super(name, desc);

--- a/src/main/java/org/kohsuke/file_leak_detector/Listener.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Listener.java
@@ -488,7 +488,7 @@ public class Listener {
 			// so the current approach does not work there any more
 			// for now we gracefully handle this and do keep file-leak-detector
 			// useful for other types of file-handle-leaks
-			System.out.println("Could not load field " + socket + " from SocketImpl: " + e);
+			System.err.println("Could not load field " + socket + " from SocketImpl: " + e);
 			return null;
 		}
 	}

--- a/src/main/java/org/kohsuke/file_leak_detector/Listener.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/Listener.java
@@ -473,13 +473,23 @@ public class Listener {
     private static final Field SOCKETIMPL_SOCKET, SOCKETIMPL_SERVER_SOCKET;
 
     static {
-        try {
-            SOCKETIMPL_SOCKET = SocketImpl.class.getDeclaredField("socket");
-            SOCKETIMPL_SERVER_SOCKET = SocketImpl.class.getDeclaredField("serverSocket");
-            SOCKETIMPL_SOCKET.setAccessible(true);
-            SOCKETIMPL_SERVER_SOCKET.setAccessible(true);
-        } catch (NoSuchFieldException e) {
-            throw new Error(e);
-        }
+		SOCKETIMPL_SOCKET = getSocketField("socket");
+		SOCKETIMPL_SERVER_SOCKET = getSocketField("serverSocket");
     }
+
+	private static Field getSocketField(String socket) {
+		try {
+			Field socketimplSocket = SocketImpl.class.getDeclaredField(socket);
+			socketimplSocket.setAccessible(true);
+
+			return socketimplSocket;
+		} catch (NoSuchFieldException e) {
+			// Java 17+ changed the implementation of Sockets and
+			// so the current approach does not work there any more
+			// for now we gracefully handle this and do keep file-leak-detector
+			// useful for other types of file-handle-leaks
+			System.out.println("Could not load field " + socket + " from SocketImpl: " + e);
+			return null;
+		}
+	}
 }

--- a/src/test/java/org/kohsuke/file_leak_detector/AgentMainTest.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/AgentMainTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Set;
 import org.junit.Test;
 import org.kohsuke.file_leak_detector.transform.ClassTransformSpec;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 public class AgentMainTest {
@@ -38,23 +37,20 @@ public class AgentMainTest {
         }
 
         Instrumentation instrumentation = mock(Instrumentation.class);
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocationOnMock) {
-                for (Object obj : invocationOnMock.getArguments()) {
-                    Class<?> clazz = (Class<?>) obj;
-                    String name = clazz.getName().replace(".", "/");
-                    assertTrue(
-                            "Tried to transform a class which is not contained in the specs: "
-                                    + name
-                                    + " ("
-                                    + clazz
-                                    + "), having remaining classes: "
-                                    + seenClasses,
-                            seenClasses.remove(name));
-                }
-                return null;
+        doAnswer((Answer<Object>) invocationOnMock -> {
+            for (Object obj : invocationOnMock.getArguments()) {
+                Class<?> clazz = (Class<?>) obj;
+                String name = clazz.getName().replace(".", "/");
+                assertTrue(
+                        "Tried to transform a class which is not contained in the specs: "
+                                + name
+                                + " ("
+                                + clazz
+                                + "), having remaining classes: "
+                                + seenClasses,
+                        seenClasses.remove(name));
             }
+            return null;
         }).when(instrumentation).retransformClasses((Class<?>) any());
 
         AgentMain.premain(null, instrumentation);

--- a/src/test/java/org/kohsuke/file_leak_detector/instrumented/PipeDemo.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/instrumented/PipeDemo.java
@@ -24,7 +24,7 @@ import org.kohsuke.file_leak_detector.Listener.SourceChannelRecord;
  * @author Denis Joubert
  */
 public class PipeDemo {
-    private static StringWriter output = new StringWriter();
+    private static final StringWriter output = new StringWriter();
 
     @BeforeClass
     public static void setup() {

--- a/src/test/java/org/kohsuke/file_leak_detector/instrumented/SocketDemo.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/instrumented/SocketDemo.java
@@ -7,6 +7,7 @@ import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketImpl;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.Collections;
@@ -15,6 +16,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.kohsuke.file_leak_detector.Listener;
 
@@ -81,6 +83,8 @@ public class SocketDemo {
 
         assertEquals(1, sockets.size());
 
+		Assume.assumeTrue("Socket is not supported on newer Java version yet", hasSocketFields());
+
         assertEquals(2, getSocketChannels());
 
         socketChannel.close();
@@ -91,6 +95,17 @@ public class SocketDemo {
         assertEquals(0, getSocketChannels());
         es.shutdownNow();
     }
+
+	private boolean hasSocketFields() {
+		try {
+			SocketImpl.class.getDeclaredField("socket");
+			SocketImpl.class.getDeclaredField("serverSocket");
+			return true;
+		} catch (NoSuchFieldException e) {
+			System.out.println("Could not find field: " + e);
+			return false;
+		}
+	}
 
     @Test
     public void testSocketLeakDetection() throws IOException, InterruptedException {
@@ -116,6 +131,8 @@ public class SocketDemo {
         }
 
         assertEquals(1, sockets.size());
+
+		Assume.assumeTrue("Socket is not supported on newer Java version yet", hasSocketFields());
 
         assertEquals(2, getSockets());
 

--- a/src/test/java/org/kohsuke/file_leak_detector/instrumented/SocketDemo.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/instrumented/SocketDemo.java
@@ -12,7 +12,6 @@ import java.nio.channels.SocketChannel;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -25,28 +24,22 @@ import org.kohsuke.file_leak_detector.Listener;
 public class SocketDemo {
     public static void main(String[] args) throws IOException {
         final ExecutorService es = Executors.newCachedThreadPool();
-        
+
         final ServerSocket ss = new ServerSocket();
         ss.bind(new InetSocketAddress("localhost",0));
 
-        es.submit(new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                while (true) {
-                    final Socket s = ss.accept();
-                    es.submit(new Callable<Object>() {
-                        @Override
-                        public Object call() throws Exception {
-                            s.close();
+        es.submit(() -> {
+			while (true) {
+				final Socket s = ss.accept();
+				es.submit(() -> {
+					s.close();
 //                            s.shutdownInput();
 //                            s.shutdownOutput();
-                            return null;
-                        }
-                    });
-                }
-            }
-        });
-        
+					return null;
+				});
+			}
+		});
+
         for (int i=0; i<10; i++) {
             int dst = ss.getLocalPort();
             Socket s = new Socket("localhost",dst);
@@ -54,7 +47,7 @@ public class SocketDemo {
 //            s.shutdownInput();
 //            s.shutdownOutput();
         }
-        
+
         System.out.println("Dumping the table");
         Listener.dump(System.out);
 
@@ -72,17 +65,14 @@ public class SocketDemo {
         serverSocket.bind(new InetSocketAddress("", 0));
 
         final Set<SocketChannel> sockets = Collections.synchronizedSet(new HashSet<>());
-        es.execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    sockets.add(serverSocket.accept());
-                }
-                catch (IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
-            }
-        });
+        es.execute(() -> {
+			try {
+				sockets.add(serverSocket.accept());
+			}
+			catch (IOException ioe) {
+				throw new UncheckedIOException(ioe);
+			}
+		});
         SocketChannel socketChannel = SocketChannel.open(new InetSocketAddress("", serverSocket.socket().getLocalPort()));
 
         while (sockets.size() < 1) {
@@ -110,17 +100,14 @@ public class SocketDemo {
         ss.bind(new InetSocketAddress("localhost",0));
 
         final Set<Socket> sockets = Collections.synchronizedSet(new HashSet<>());
-        es.execute(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    sockets.add(ss.accept());
-                }
-                catch (IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
-            }
-        });
+        es.execute(() -> {
+			try {
+				sockets.add(ss.accept());
+			}
+			catch (IOException ioe) {
+				throw new UncheckedIOException(ioe);
+			}
+		});
 
         Socket s = new Socket("localhost", ss.getLocalPort());
 


### PR DESCRIPTION
Do not fail if fields in class SocketImpl are not available. 

This is the case on Java 17+ where the implementation of Sockets was
changed fundamentally and thus the current approach does not work
any more.