### PR TITLE
Remove redundant `project.build.sourceEncoding` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,6 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
     <asm.version>9.3</asm.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spotbugs.excludeFilterFile>${project.basedir}/src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
   </properties>
 


### PR DESCRIPTION
This has been in the parent POM since https://github.com/jenkinsci/pom/pull/257 which was released in 1.76.