### PR TITLE
Partial forward compatibility for mockito upgrade

### DIFF
--- a/src/test/java/org/kohsuke/file_leak_detector/AgentMainTest.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/AgentMainTest.java
@@ -56,7 +56,7 @@ public class AgentMainTest {
         AgentMain.premain(null, instrumentation);
 
         verify(instrumentation, times(1)).addTransformer(any(), anyBoolean());
-        verify(instrumentation, times(1)).retransformClasses((Class<?>) any());
+        verify(instrumentation, times(1)).retransformClasses(any(Class[].class));
 
         // the following are not available in all JVMs
         seenClasses.remove("sun/nio/ch/SocketChannelImpl");


### PR DESCRIPTION
see https://github.com/jenkinsci/lib-file-leak-detector/pull/126#issuecomment-1426891279

The existing code doesn't work on new mockito, this change fixes one issue, I wasn't able to track down the other but given this works on the existing version may as fix this part now.