### PR TITLE
Adapt to removal of `PlainSocketImpl`

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -132,7 +132,6 @@ public class AgentMain {
                 FileInputStream.class,
                 FileOutputStream.class,
                 RandomAccessFile.class,
-                Class.forName("java.net.PlainSocketImpl"),
                 ZipFile.class,
                 AbstractSelectableChannel.class,
                 AbstractInterruptibleChannel.class,
@@ -142,6 +141,8 @@ public class AgentMain {
 
         addIfFound(classes, "sun.nio.ch.SocketChannelImpl");
         addIfFound(classes, "java.net.AbstractPlainSocketImpl");
+        // TODO handle sun.nio.ch.NioSocketImpl
+        addIfFound(classes, "java.net.PlainSocketImpl");
         addIfFound(classes, "sun.nio.fs.UnixDirectoryStream");
         addIfFound(classes, "sun.nio.fs.UnixSecureDirectoryStream");
         addIfFound(classes, "sun.nio.fs.WindowsDirectoryStream");


### PR DESCRIPTION
Follows up #84, which adapted to https://github.com/openjdk/jdk/commit/7e14aeb1334cfc6b5c1c314e1dae2a579e0f204b in Java 13+. In Java 18, https://github.com/openjdk/jdk/commit/326b2e13447d734f84271942cc8154e30486fa7d deleted the class altogether, and so without this fix the detector crashes with `ClassNotFoundException: java.net.PlainSocketImpl`. (I am trying to use it on a ~21 dev build, so far without success—no error messages, but does not intercept any file events either.)