### PR TITLE
Degrade gracefully on Java 19+

### DIFF
--- a/src/test/java/org/kohsuke/file_leak_detector/AgentMainTest.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/AgentMainTest.java
@@ -60,9 +60,12 @@ public class AgentMainTest {
 
         // the following are not available in all JVMs
         seenClasses.remove("sun/nio/ch/SocketChannelImpl");
-        seenClasses.remove("java/net/AbstractPlainSocketImpl");
         seenClasses.remove("sun/nio/fs/UnixDirectoryStream");
         seenClasses.remove("sun/nio/fs/UnixSecureDirectoryStream");
+        if (Runtime.version().feature() >= 19) {
+            seenClasses.remove("java/net/AbstractPlainSocketImpl");
+            seenClasses.remove("java/net/PlainSocketImpl");
+        }
 
         assertTrue(
                 "Had classes in the spec which were not instrumented: " + seenClasses,


### PR DESCRIPTION
Without fixing #86, make it so that this module at least degrades gracefully when run on Java 19+, allowing users to use the file handle capability without using the socket capability (which does not work on Java 17+).

### Testing done

Ran the unit tests on Java 11, 17, 19, 20, and 21. Also ran the module in a real Jenkins controller and verified I could successfully use the file handle capability on all of those Java versions (at least in a simple use case).