### PR TITLE
Use spotbugs 4.8.2 with more exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
     <asm.version>9.6</asm.version>
+    <!-- TODO: Remove when parent pom is using this version or newer -->
+    <!-- https://github.com/jenkinsci/pom/pull/510 -->
+    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
+    <spotbugs.omitVisitors>FindReturnRef,ConstructorThrow</spotbugs.omitVisitors>
   </properties>
 
   <dependencies>

--- a/src/spotbugs/excludesFilter.xml
+++ b/src/spotbugs/excludesFilter.xml
@@ -4,10 +4,14 @@
     Exclusions in this section have been triaged and determined to be false positives.
   -->
   <Match>
-    <Or>
-      <!-- Pending https://github.com/spotbugs/spotbugs/issues/1515 -->
-      <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
-    </Or>
+    <!-- Pending https://github.com/spotbugs/spotbugs/issues/1515 -->
+    <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
+  </Match>
+  <Match>
+    <!-- Preserve API compatibility -->
+    <Bug pattern="PA_PUBLIC_PRIMITIVE_ATTRIBUTE"/>
+    <Class name="org.kohsuke.file_leak_detector.Listener"/>
+    <Field name="THRESHOLD"/>
   </Match>
   <!--
     Here lies technical debt. Exclusions in this section have not yet been triaged. When working on


### PR DESCRIPTION
## Use spotbugs 4.8.2 with more exclusions

Prep for

* https://github.com/jenkinsci/pom/pull/510

Part of the checklist in:

* https://github.com/jenkinsci/jenkins/pull/8803

Needs to be merged on or before the update of the parent pom that updates to use spotbugs 4.8.2.

### Testing done

Confirmed that automated tests pass with this change and that no spotbugs warnings are reported.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
