### PR TITLE
Rely on parent pom spotbugs configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,10 +34,6 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/lib-${project.artifactId}</gitHubRepo>
     <asm.version>9.6</asm.version>
-    <!-- TODO: Remove when parent pom is using this version or newer -->
-    <!-- https://github.com/jenkinsci/pom/pull/510 -->
-    <spotbugs-maven-plugin.version>4.8.2.0</spotbugs-maven-plugin.version>
-    <spotbugs.omitVisitors>FindReturnRef,ConstructorThrow</spotbugs.omitVisitors>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Rely on parent pom spotbugs configuration

Remove 800114972067b6991b2e5ab073da51639ad7c893 workaround that was added in pull request:

* #164

### Testing done

Confirmed that spotbugs warnings are still silent after this workaround is removed.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
