### PR TITLE
Add instrumentation for more implementations of DirectoryStream.close()

### DIFF
--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -154,6 +154,7 @@ public class AgentMain {
         addIfFound(classes, "sun.nio.fs.UnixSecureDirectoryStream");
         addIfFound(classes, "sun.nio.fs.WindowsDirectoryStream");
         addIfFound(classes, "jdk.internal.jrtfs.JrtDirectoryStream");
+        addIfFound(classes, "jdk.nio.zipfs.ZipDirectoryStream");
 
         instrumentation.retransformClasses(classes.toArray(new Class[0]));
 
@@ -322,6 +323,7 @@ public class AgentMain {
         }
 
         spec.add(new ClassTransformSpec("jdk/internal/jrtfs/JrtDirectoryStream", new CloseInterceptor("close")));
+        spec.add(new ClassTransformSpec("jdk/nio/zipfs/ZipDirectoryStream", new CloseInterceptor("close")));
 
         /*
          * Detect selectors, which may open native pipes and anonymous inodes for event polling.

--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -153,6 +153,7 @@ public class AgentMain {
         addIfFound(classes, "sun.nio.fs.UnixDirectoryStream");
         addIfFound(classes, "sun.nio.fs.UnixSecureDirectoryStream");
         addIfFound(classes, "sun.nio.fs.WindowsDirectoryStream");
+        addIfFound(classes, "jdk.internal.jrtfs.JrtDirectoryStream");
 
         instrumentation.retransformClasses(classes.toArray(new Class[0]));
 
@@ -319,6 +320,9 @@ public class AgentMain {
             Collections.addAll(
                     spec, new ClassTransformSpec("sun/nio/fs/WindowsDirectoryStream", new CloseInterceptor("close")));
         }
+
+        spec.add(new ClassTransformSpec("jdk/internal/jrtfs/JrtDirectoryStream", new CloseInterceptor("close")));
+
         /*
          * Detect selectors, which may open native pipes and anonymous inodes for event polling.
          */

--- a/src/test/java/org/kohsuke/file_leak_detector/instrumented/FileDemo.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/instrumented/FileDemo.java
@@ -437,4 +437,27 @@ public class FileDemo {
                 findPathRecordByName(new File(".").toPath()),
                 "Should not have a leftover entry for '.', but found: " + Listener.getCurrentOpenFiles());
     }
+
+    @Test
+    public void testJRTFileSystem() throws IOException {
+        FileSystem fileSystem = FileSystems.getFileSystem(URI.create("jrt:/"));
+        Path path = fileSystem.getPath("/modules");
+        try (DirectoryStream<Path> ds = Files.newDirectoryStream(path)) {
+            assertNotNull(ds);
+
+            assertNotNull(findPathRecord(path), "No file record for file=" + path + " found");
+
+            assertThat(
+                    "Did not have the expected type of 'marker' object: " + obj,
+                    obj,
+                    instanceOf(DirectoryStream.class));
+        }
+        assertNull(findPathRecord(path), "File record for file=" + path + " not removed");
+        assertThat("Did not have the expected type of 'marker' object: " + obj, obj, instanceOf(DirectoryStream.class));
+        assertThat("Did not have the expected type of 'marker' object: " + obj, obj, instanceOf(DirectoryStream.class));
+
+        String traceOutput = output.toString();
+        assertThat(traceOutput, containsString("Opened " + tempFile));
+        assertThat(traceOutput, containsString("Closed " + tempFile));
+    }
 }

--- a/src/test/java/org/kohsuke/file_leak_detector/instrumented/FileDemo.java
+++ b/src/test/java/org/kohsuke/file_leak_detector/instrumented/FileDemo.java
@@ -34,7 +34,6 @@ import org.apache.commons.io.file.NoopPathVisitor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.kohsuke.file_leak_detector.ActivityListener;
 import org.kohsuke.file_leak_detector.Listener;
@@ -392,7 +391,6 @@ public class FileDemo {
         assertThat(traceOutput, containsString("Closed " + new File(url.getFile()).getAbsolutePath()));
     }
 
-    @Disabled("Reported as https://bugs.openjdk.org/browse/JDK-8348037")
     @Test
     public void testZipFileLeakWalkFileTree() {
         URL url = getClass().getResource("/test.zip");
@@ -428,7 +426,6 @@ public class FileDemo {
         assertThat(traceOutput, containsString("Closed " + new File(url.getFile()).getAbsolutePath()));
     }
 
-    @Disabled("Reported as https://bugs.openjdk.org/browse/JDK-8348037")
     @Test
     public void testWalkFileTree() throws IOException {
         Files.walkFileTree(Path.of("."), new NoopPathVisitor());


### PR DESCRIPTION
This adds instrumentation of two missing "close()" methods of implementations of DirectoryStream in the JDK. 

JrtDirectoryStream and ZipDirectoryStream are now handled properly as well and do not lead to false-positive file-leak reports any longer.

I originally thought this is a bug in the JDK itself and reported it at https://bugs.openjdk.org/browse/JDK-8348037, but it turns out this is actually a problem in file-leak-detector.

### Testing done

Added/enabled test-cases verify that leaks are detected properly.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
