### PR TITLE
Support Java 25

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,6 @@
  */
 buildPlugin(useContainerAgent: true, configurations: [
   [ platform: 'windows', jdk: '17' ],
-  [ platform: 'linux', jdk: '21' ]
+  [ platform: 'linux', jdk: '21' ],
+  [ platform: 'linux', jdk: '25' ],
 ])

--- a/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/AgentMain.java
@@ -396,6 +396,15 @@ public class AgentMain {
                         "openFileString",
                         Object.class,
                         FileDescriptor.class,
+                        String.class),
+                // this is for java 25+ - which added a boolean parameter
+                new ReturnFromStaticMethodInterceptor(
+                        "open",
+                        "(Ljava/io/FileDescriptor;Ljava/lang/String;ZZZZLjava/io/Closeable;)Ljava/nio/channels/FileChannel;",
+                        7,
+                        "openFileString",
+                        Object.class,
+                        FileDescriptor.class,
                         String.class)));
         return spec;
     }
@@ -637,18 +646,11 @@ public class AgentMain {
                 index[i] = i - 1;
             }
 
-            Label start = new Label();
-            Label end = new Label();
-            g.visitLocalVariable("result", "java/lang/Object", null, start, end, returnLocalVarIndex);
-            g.visitLabel(start);
-
             // return value is currently on top of the stack
             // result = {return value}
             g.astore(returnLocalVarIndex);
 
             g.invokeAppStatic(Listener.class, listenerMethod, listenerMethodArgs, index);
-
-            g.visitLabel(end);
 
             // restore the stack so that the ARETURN has something to return
             g.aload(returnLocalVarIndex);

--- a/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
+++ b/src/main/java/org/kohsuke/file_leak_detector/transform/CodeGenerator.java
@@ -62,11 +62,11 @@ public class CodeGenerator extends MethodVisitor {
     }
 
     public void aload(int i) {
-        super.visitIntInsn(ALOAD, i);
+        super.visitVarInsn(ALOAD, i);
     }
 
     public void astore(int i) {
-        super.visitIntInsn(ASTORE, i);
+        super.visitVarInsn(ASTORE, i);
     }
 
     public void pop() {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This was AI assisted, output from LLM:

> This turned out to be three latent bugs in the agent's bytecode generation plus one JDK 25 adaptation — JDK 25 is the first release to run full class-file validation on retransformed core classes, which exposed malformed bytecode the agent had been producing all along:
>
> The root cause (transform/CodeGenerator.java): aload/astore were emitted via visitIntInsn instead of visitVarInsn. The raw bytes happen to encode identically, so the code executed for years — but ASM's COMPUTE_FRAMES/COMPUTE_MAXS never saw a variable store, so the transformed classes had max_locals too small and wrong stack map frames. Unverified JDKs tolerated it; JDK 25's verifier rejects it at premain, killing the JVM.
>
> Two more in AgentMain.java's ReturnFromStaticMethodInterceptor:
> - The injected LocalVariableTable entry used "java/lang/Object" (internal name) where the spec requires the descriptor "Ljava/lang/Object;" → ClassFormatError.
> - Methods with multiple return instructions got duplicate identical LVT entries (one per return) → also rejected. Since the entries were zero-length and carried no debug value, I removed the visitLocalVariable emission entirely.
>
> The JDK 25 adaptation: sun.nio.ch.FileChannelImpl.open gained a sixth boolean parameter, so neither existing interceptor descriptor matched and Files.newBufferedWriter opens went untracked (caught by FileDemo.openCloseFilesBufferedWriter). Added a third interceptor for the new signature, using local slot 7 (past all seven parameters).

### Testing done

CI
and LLM did:
> mvn clean verify passes on Zulu 25.0.1, Azul 21.0.11, and JDK 17, and a standalone -javaagent smoke test on Java 25 installs the agent and tracks a file open/close correctly. The debug harness I used to bisect lives in the session scratchpad, not your repo.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
